### PR TITLE
Added support for polling the external IP service

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,15 @@ Update the DNS A record for a specific domain and sub-domain to the External IP 
     dns-dodo update-dns --pat=[your-pat] --domain=[domain-name] --sub-domain=home
 
 
-----
+Poll for changes to your external IP using the `--poll` flag (`-p`).
+
+    dns-dodo update-dns --pat=[your-pat] --domain=[domain-name] --sub-domain=home -p
+
+
+Polling uses a default interval of 1 minute. Use the `--pollfreq` (`-f`) flag to customise the polling frequency.
+The following will poll for updates once per hour.
+
+    dns-dodo update-dns --pat=[your-pat] --domain=[domain-name] --sub-domain=home -p -f=1h
 
 
 ## Building from Source

--- a/dns-dodo.go
+++ b/dns-dodo.go
@@ -383,10 +383,18 @@ func main() {
 				dnsDodo.DOPersonalAccessToken = c.String("pat")
 				dnsDodo.EstablishGoDoClient()
 
+				var lastIP string
 				updateFunc := func(polling bool) {
 					ip := dnsDodo.getExternalIP()
 					dnsDodo.CheckIPV4(ip) // check the ip is valid before we attempt to connect to Digital Ocean
-					dnsDodo.UpdateDNSEntry(c.String("domain"), c.String("sub-domain"), ip, polling)
+
+					// If IP hasn't changed since we last polled, don't update
+					if ip != lastIP {
+						dnsDodo.UpdateDNSEntry(c.String("domain"), c.String("sub-domain"), ip, polling)
+					} else {
+						fmt.Printf("[%s] IP (%s) hasn't changed since last poll\n", time.Now(), ip)
+					}
+					lastIP = ip
 				}
 
 				if !c.IsSet("poll") {

--- a/dns-dodo.go
+++ b/dns-dodo.go
@@ -274,7 +274,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "dns-dodo"
 	app.Usage = "Dynamic DNS sub-domain updater for Digital Ocean."
-	app.Version = "1.1"
+	app.Version = "1.2"
 
 	// setup the default flags that are optional
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
The dodo can now poll the external IP service using `--poll`.
The default polling interval is 1 minute, however, it can be changed by providing `--pollfreq=<duration>`.
When polling, no update will be posted to DO if the external IP service reports that the IP didn't change from the previous poll.